### PR TITLE
Fix: Critical bugs in MailMod and refine RedeemMod item handling

### DIFF
--- a/src/main/java/com/coffeecat2006/mail/MailCommands.java
+++ b/src/main/java/com/coffeecat2006/mail/MailCommands.java
@@ -57,25 +57,23 @@ public class MailCommands {
                 // 刪除信件，含 confirm/cancel
                 .then(CommandManager.literal("delete")
                     .then(CommandManager.argument("target", StringArgumentType.string())
-                        .executes(ctx -> MailManager.delete(
+                        .executes(ctx -> MailManager.delete( // Initial call, shows confirmation
                             ctx.getSource(),
                             StringArgumentType.getString(ctx, "target"),
                             false
                         ))
-                        .then(CommandManager.literal("confirm")
+                        .then(CommandManager.literal("confirm") // Confirms deletion of "target"
                             .executes(ctx -> MailManager.delete(
                                 ctx.getSource(),
-                                StringArgumentType.getString(ctx, "target"),
+                                StringArgumentType.getString(ctx, "target"), // Uses "target" from parent
                                 true
-                            ))
-                        )
-                        .then(CommandManager.literal("cancel")
+                            )))
+                        .then(CommandManager.literal("cancel") // Cancels deletion of "target"
                             .executes(ctx -> MailManager.delete(
                                 ctx.getSource(),
-                                StringArgumentType.getString(ctx, "target"),
-                                false
-                            ))
-                        )
+                                StringArgumentType.getString(ctx, "target") + " cancel_true", // Uses "target" from parent and appends marker
+                                true // Process immediately
+                            )))
                     )
                 )
                 // 幫助


### PR DESCRIPTION
This commit addresses several issues in the MailMod and improves the robustness of item handling in the RedeemMod.

MailMod Fixes:
- Fixed item duplication exploit: Operators sending mail with items from their off-hand will now correctly have the item removed.
- Corrected /mail delete command:
    - The 'cancel' subcommand now functions as expected, preventing accidental deletions.
    - Confirmation flow for deletion is now reliable.
- Fixed mail broadcast issue: Prevents a NullPointerException if the recipient is offline and ensures the recipient doesn't receive duplicate notifications for new mail.
- Added mail logging: Successfully sent mails are now logged in MailState.

RedeemMod Enhancements:
- Refined item handling for /redeem add:
    - Clarified behavior when executed by players (uses off-hand) vs. non-players (no items, with feedback).
    - Improved logging for item addition status.
- Refined item handling for /redeem modify item transform:
    - Command now requires player execution.
    - Provides clear feedback if your off-hand is empty (results in clearing items).
    - Logs the transformation details.
- Refined item handling for /redeem modify item add:
    - Command now requires player execution.
    - Provides clear feedback if your off-hand is empty (no item added).
    - Logs item addition.
- Verified that the `items` list in `RedeemState` is correctly handled for mutability during deserialization (no change was needed).

Overall, these changes improve the stability, security, and user-friendliness of both mail and redeem code features.